### PR TITLE
feat config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target/
 html/
+bucket3.yaml
+posts/
+skel/
+templates/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,9 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sled",
+ "tempfile",
  "time",
+ "url",
  "walkdir",
 ]
 
@@ -337,6 +339,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +439,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,10 +463,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -476,6 +623,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -583,6 +736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +758,15 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -633,6 +801,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -813,6 +987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +1027,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "syntect"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1057,19 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -930,6 +1134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1168,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1198,24 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1149,6 +1398,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,4 +1422,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ comrak = "0.21"
 sled = "0.34"
 walkdir = "2.5"
 time = { version = "0.3", features = ["parsing", "formatting"] }
+url = { version = "2.5", default-features = false }
+
+[dev-dependencies]
+tempfile = "3.12"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ bucket3 init
 ```
 
 The `init` command creates the starter structure: `html/`, `posts/`, `templates/`, `skel/`, and a `bucket3.yaml` configuration file. The command is idempotent and prints `Initialized` when the workspace is ready.
+
+### Configuration
+
+`bucket3.yaml` drives site-wide settings. All fields are optional; missing values fall back to:
+
+```
+base_url: "https://example.com"
+homepage_posts: 5
+date_format: "[year]-[month]-[day]"
+```
+
+`base_url` must be an absolute `http` or `https` URL, `homepage_posts` must be positive, and `date_format` accepts either a custom [`time` format description`](https://docs.rs/time/latest/time/format_description/) or the keyword `RFC3339`. The configuration is injected into templates as `config`, and templates can call `{{ now() }}` (or `{{ now('RFC3339') }}`) to render the current timestamp.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -11,6 +11,7 @@ const CONFIG_FILE: &str = "bucket3.yaml";
 const DEFAULT_CONFIG: &str = r#"title: "My Bucket3 Site"
 base_url: "https://example.com"
 homepage_posts: 5
+date_format: "[year]-[month]-[day]"
 "#;
 
 const BASE_TEMPLATE: &str = r#"<!doctype html>
@@ -143,11 +144,11 @@ fn write_if_missing(path: &Path, contents: &str) -> Result<()> {
     if path.exists() {
         return Ok(());
     }
-    if let Some(parent) = path.parent() {
-        if !parent.exists() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
-        }
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
     }
     let mut file =
         fs::File::create(path).with_context(|| format!("failed to create {}", path.display()))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,196 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use time::format_description::{self, FormatItem};
+use url::Url;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct Config {
+    pub title: Option<String>,
+    pub base_url: String,
+    pub homepage_posts: usize,
+    pub date_format: String,
+}
+
+impl Config {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("failed to read config file {}", path.display()))?;
+        let config: Config =
+            serde_yaml::from_str(&raw).with_context(|| invalid_yaml_message(path))?;
+        config.validate(path)?;
+        Ok(config)
+    }
+
+    pub fn validate(&self, origin: &Path) -> Result<()> {
+        validate_url(&self.base_url, origin)?;
+        if self.homepage_posts == 0 {
+            bail!(
+                "{}: homepage_posts must be greater than zero",
+                origin.display()
+            );
+        }
+        validate_format(&self.date_format, origin)?;
+        Ok(())
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            title: None,
+            base_url: "https://example.com".to_string(),
+            homepage_posts: 5,
+            date_format: "[year]-[month]-[day]".to_string(),
+        }
+    }
+}
+
+fn invalid_yaml_message(path: &Path) -> String {
+    format!("{}: invalid YAML", path.display())
+}
+
+fn validate_url(value: &str, origin: &Path) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{}: base_url must not be empty", origin.display());
+    }
+    let url = Url::parse(value)
+        .with_context(|| format!("{}: base_url must be an absolute URL", origin.display()))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        bail!("{}: base_url must use http or https", origin.display());
+    }
+    Ok(())
+}
+
+fn validate_format(value: &str, origin: &Path) -> Result<()> {
+    parse_format(value).with_context(|| {
+        format!(
+            "{}: date_format '{}' is invalid (see https://docs.rs/time/latest/time/format_description)",
+            origin.display(), value
+        )
+    })?;
+    Ok(())
+}
+
+fn parse_format(value: &str) -> Result<()> {
+    if value == "RFC3339" {
+        return Ok(());
+    }
+
+    let items = format_description::parse(value)?;
+    if !items
+        .iter()
+        .any(|item| matches!(item, FormatItem::Component(_)))
+    {
+        bail!("date_format must contain at least one date or time component");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn default_when_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        let config = Config::load(&path).unwrap();
+        assert_eq!(config, Config::default());
+    }
+
+    #[test]
+    fn load_valid_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        fs::write(
+            &path,
+            r#"title: "Bucket"
+base_url: "https://example.com/blog"
+homepage_posts: 8
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&path).unwrap();
+        assert_eq!(config.title.as_deref(), Some("Bucket"));
+        assert_eq!(config.base_url, "https://example.com/blog");
+        assert_eq!(config.homepage_posts, 8);
+        assert_eq!(config.date_format, "[year]-[month]-[day]");
+    }
+
+    #[test]
+    fn reject_invalid_url() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        fs::write(
+            &path,
+            r#"title: "Bucket"
+base_url: "ftp://example.com"
+homepage_posts: 3
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(&path).unwrap_err();
+        let message = format!("{error}");
+        assert!(message.contains("base_url must use http or https"));
+    }
+
+    #[test]
+    fn reject_zero_homepage_posts() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        fs::write(
+            &path,
+            r#"base_url: "https://example.com"
+homepage_posts: 0
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(&path).unwrap_err();
+        assert!(format!("{error}").contains("homepage_posts must be greater than zero"));
+    }
+
+    #[test]
+    fn reject_invalid_date_format() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        fs::write(
+            &path,
+            r#"base_url: "https://example.com"
+date_format: "???"
+"#,
+        )
+        .unwrap();
+
+        let error = Config::load(&path).unwrap_err();
+        assert!(format!("{error}").contains("date_format"));
+    }
+
+    #[test]
+    fn accept_rfc3339_keyword() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bucket3.yaml");
+        fs::write(
+            &path,
+            r#"base_url: "https://example.com"
+date_format: "RFC3339"
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(&path).unwrap();
+        assert_eq!(config.date_format, "RFC3339");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod commands;
-
-use crate::cli::Command;
+pub mod config;
+pub mod template;
 
 fn main() {
     let app = cli::Cli::build();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,0 +1,85 @@
+use anyhow::Result;
+use minijinja::value::Value;
+use minijinja::{Environment, ErrorKind};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::config::Config;
+
+pub fn environment(config: &Config) -> Result<Environment<'static>> {
+    let mut env = Environment::new();
+    env.add_global("config", Value::from_serialize(config));
+
+    let default_format = config.date_format.clone();
+    env.add_function(
+        "now",
+        move |format: Option<&str>| -> Result<String, minijinja::Error> {
+            let format = format.unwrap_or(&default_format);
+
+            if format.eq_ignore_ascii_case("RFC3339") {
+                return OffsetDateTime::now_utc().format(&Rfc3339).map_err(|err| {
+                    minijinja::Error::new(
+                        ErrorKind::InvalidOperation,
+                        format!("failed to format now(): {err}"),
+                    )
+                });
+            }
+
+            let description = time::format_description::parse(format).map_err(|err| {
+                minijinja::Error::new(
+                    ErrorKind::InvalidOperation,
+                    format!("invalid date format '{format}' passed to now(): {err}"),
+                )
+            })?;
+
+            OffsetDateTime::now_utc()
+                .format(&description)
+                .map_err(|err| {
+                    minijinja::Error::new(
+                        ErrorKind::InvalidOperation,
+                        format!("failed to format now(): {err}"),
+                    )
+                })
+        },
+    );
+
+    Ok(env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_available_in_templates() {
+        let mut config = Config::default();
+        config.title = Some("Bucket".to_string());
+        let mut env = environment(&config).unwrap();
+        env.add_template("greet", "{{ config.title }}").unwrap();
+
+        let rendered = env.get_template("greet").unwrap().render(()).unwrap();
+        assert_eq!(rendered, "Bucket");
+    }
+
+    #[test]
+    fn now_helper_uses_config_format() {
+        let mut config = Config::default();
+        config.date_format = "[year]".to_string();
+        let mut env = environment(&config).unwrap();
+        env.add_template("when", "{{ now() }}").unwrap();
+
+        let rendered = env.get_template("when").unwrap().render(()).unwrap();
+        assert_eq!(rendered.len(), 4);
+    }
+
+    #[test]
+    fn now_helper_accepts_rfc3339_keyword() {
+        let config = Config::default();
+        let mut env = environment(&config).unwrap();
+        env.add_template("when", "{{ now('RFC3339') }}").unwrap();
+
+        let rendered = env.get_template("when").unwrap().render(()).unwrap();
+        assert!(rendered.contains('T'));
+        assert!(rendered.ends_with('Z'));
+    }
+}


### PR DESCRIPTION
## Summary
  - add a Config loader with defaults, YAML parsing, and validation of base_url/homepage_posts/date_format
  - inject config + a now() helper into the Minijinja environment so templates can render {{ config.* }} and
  timestamps
  - document the config defaults and ignore init-generated artifacts to keep the repo tidy