### PR TITLE
feat:content-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,26 @@ date_format: "[year]-[month]-[day]"
 ```
 
 `base_url` must be an absolute `http` or `https` URL, `homepage_posts` must be positive, and `date_format` accepts either a custom [`time` format description`](https://docs.rs/time/latest/time/format_description/) or the keyword `RFC3339`. The configuration is injected into templates as `config`, and templates can call `{{ now() }}` (or `{{ now('RFC3339') }}`) to render the current timestamp.
+
+### Posts
+
+Store posts under `posts/` in any directory layout. Each directory that contains exactly one Markdown or HTML file (with a `.md` or `.html` extension) is considered a post; all other files in that directory are treated as assets. Every post file must start with YAML front matter:
+
+```
+---
+title: "Optional title"
+date: "2025-03-12T09:30:00Z"
+slug: "custom-slug"
+tags:
+  - example
+abstract: "Short teaser"
+attached:
+  - files/data.csv
+images:
+  - cover.jpg
+video_url: "https://example.com/video.mp4"
+---
+Body goes here…
+```
+
+`slug` falls back to the directory name (kebab-cased) when omitted. Dates must use RFC 3339, and the permalink for a post is `/yyyy/mm/dd/slug/`. The `attached` and `images` lists stay relative to the post directory so later build steps can copy them alongside the rendered HTML.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -61,6 +61,7 @@ tags:
   - welcome
 abstract: "Kick the tires on the generator."
 attached: []
+images: []
 ---
 
 This is the starter post. Edit it or drop in your own content to get going.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 pub mod config;
+pub mod content;
 pub mod template;
 
 fn main() {


### PR DESCRIPTION
## Summary
- add content module to walk posts/, enforce a single .md/.html per post, parse YAML front matter, and build Post
  structs with slugs, permalinks, and asset lists (src/content/mod.rs:12)
  - export the module for future wiring, extend bucket3 init scaffold with updated config defaults and sample front
  matter, and document the post schema in the README (src/main.rs:1, src/commands/init.rs:11, README.md:21)